### PR TITLE
Version bump to 0.0.3 and fix NPM publish workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,6 @@ jobs:
       run: pnpm run build
     
     - name: Publish to NPM
-      run: pnpm publish
+      run: pnpm publish --no-git-checks
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-eslint-extended-switch-exhaustiveness",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ESLint plugin that enforces 'throw new Error(`${value satisfies never} ...`)' in default cases for union types",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
This PR bumps the package version to 0.0.3 and fixes the NPM publish workflow in GitHub Actions.

## Changes
- **Version Update**: Bumped package version from 0.0.2 to 0.0.3 in package.json
- **CI/CD Fix**: Added \ flag to the NPM publish command in the CD workflow to prevent git-related publish failures

## Related Issue
Closes #9

## Test plan
- [x] Version bump is reflected in package.json
- [x] NPM publish workflow includes the --no-git-checks flag
- [x] Verify CI/CD pipeline runs successfully